### PR TITLE
Update index.js to also export Consumer and Provider from Context

### DIFF
--- a/packages/react-jsx-highcharts/src/index.js
+++ b/packages/react-jsx-highcharts/src/index.js
@@ -69,6 +69,7 @@ export const WindBarbSeries = withSeriesType('WindBarb');
 export const XRangeSeries = withSeriesType('XRange');
 
 // Providers
+export { Consumer, Provider } from './components/HighchartsContext';
 export { default as provideHighcharts }  from './components/HighchartsProvider';
 export { default as provideChart }  from './components/ChartProvider';
 export { default as provideAxis }  from './components/AxisProvider';


### PR DESCRIPTION
Creates the ability to provide a custom withHighcharts HOC. I need this because I am using react-docgen to generate documentation for the Highcharts components. react-docgen creates an error with the existing HOC.

It would be awesome if you could merge this simple addition to the export list. Would help me not to have to fork / republish.